### PR TITLE
🚀  Add nullability to find signature fixes

### DIFF
--- a/src/classes/sequelize-service.ts
+++ b/src/classes/sequelize-service.ts
@@ -109,12 +109,12 @@ export class SequelizeService<W extends {}, R extends W, C extends {} = {}> exte
     return new Collection(objects);
   }
 
-  public async findOne<KR extends keyof R, KC extends keyof C = keyof {}>(filters: TFilters<R>, options: TFindOneOptions<R, C, KR, KC> = {}): Promise<Pick<R, KR> & Pick<C, KC>> {
+  public async findOne<KR extends keyof R, KC extends keyof C = keyof {}>(filters: TFilters<R>, options: TFindOneOptions<R, C, KR, KC> = {}): Promise<(Pick<R, KR> & Pick<C, KC>) | null> {
     const [ object ] = await this.find(filters, Object.assign(options, { limit: 1 }));
     return object || null;
   }
 
-  public async findByPrimaryKey<KR extends keyof R, KC extends keyof C = keyof {}>(pk: string | number, options: TFindByPrimaryKeyOptions<R, C, KR, KC> = {}): Promise<Pick<R, KR> & Pick<C, KC>> {
+  public async findByPrimaryKey<KR extends keyof R, KC extends keyof C = keyof {}>(pk: string | number, options: TFindByPrimaryKeyOptions<R, C, KR, KC> = {}): Promise<(Pick<R, KR> & Pick<C, KC>) | null> {
     return await this.findOne({ [this.getPrimaryKeyField()]: pk } as any, options);
   }
 
@@ -167,7 +167,7 @@ export class SequelizeService<W extends {}, R extends W, C extends {} = {}> exte
         const primaryKeyFilter = (<any>candidate)[this.getPrimaryKeyField()];
         await this.updateByPrimaryKey(primaryKeyFilter, values, options);
         // Return the updated object for consistency
-        return await this.findByPrimaryKey(primaryKeyFilter, options);
+        return <R & Pick<C, KC>>await this.findByPrimaryKey(primaryKeyFilter, options);
       } else {
         return await this.create(values, options);
       }

--- a/src/interfaces/sequelize-service.ts
+++ b/src/interfaces/sequelize-service.ts
@@ -17,12 +17,12 @@ export interface ISequelizeService<W extends {}, R extends W, C extends {}> {
   createMany<KR extends keyof R, KC extends keyof C = keyof {}>(objects: W[], options?: TCreateOptions<R, C, KC>): Promise<Collection<R & Pick<C, KC>>>;
   find<KR extends keyof R, KC extends keyof C = keyof {}>(filters: TFilters<R>, options?: TFindOptions<R, C, KR, KC>): Promise<Collection<Pick<R, KR> & Pick<C, KC>>>;
   warn(condition: boolean, message: string, data?: object): void;
-  findOne<KR extends keyof R, KC extends keyof C = keyof {}>(filters: TFilters<R>, options?: TFindOneOptions<R, C, KR, KC>): Promise<Pick<R, KR> & Pick<C, KC>>;
-  findByPrimaryKey<KR extends keyof R, KC extends keyof C = keyof {}>(pk: string | number, options?: TFindByPrimaryKeyOptions<R, C, KR, KC>): Promise<Pick<R, KR> & Pick<C, KC>>;
+  findOne<KR extends keyof R, KC extends keyof C = keyof {}>(filters: TFilters<R>, options?: TFindOneOptions<R, C, KR, KC>): Promise<(Pick<R, KR> & Pick<C, KC>) | null>;
+  findByPrimaryKey<KR extends keyof R, KC extends keyof C = keyof {}>(pk: string | number, options?: TFindByPrimaryKeyOptions<R, C, KR, KC>): Promise<(Pick<R, KR> & Pick<C, KC>) | null>;
   findByPrimaryKeys<KR extends keyof R, KC extends keyof C = keyof {}>(pks: string[] | number[], options?: TFindByPrimaryKeyOptions<R, C, KR, KC>): Promise<Collection<Pick<R, KR> & Pick<C, KC>>>;
   update(filters: TFilters<R>, values: TValues<W>, options?: TUpdateOptions<R>): Promise<number>;
   updateByPrimaryKey(pk: string | number, values: TValues<W>, options?: TUpdateByPrimaryKeyOptions<R>): Promise<number>;
   delete(filters: TFilters<R>, options?: TDeleteOptions<R>): Promise<number>;
   count(filters: TFilters<R>, options?: TCountOptions<R>): Promise<number>;
-  replaceOne<KR extends keyof R, KC extends keyof C = keyof {}>(filters: TFilters<R>, values: W, options?: TReplaceOneOptions<R, C, KC>): Promise<R & Pick<C, KC>>;
+  replaceOne<KC extends keyof C = keyof {}>(filters: TFilters<R>, values: W, options?: TReplaceOneOptions<R, C, KC>): Promise<R & Pick<C, KC>>;
 }

--- a/test/classes/sequelize-service.test.ts
+++ b/test/classes/sequelize-service.test.ts
@@ -348,7 +348,11 @@ describe('SequelizeService', function () {
     it('should compute properties object', async () => {
       await userService.create({ email: 'foo', password: 'bar', date_of_birth: ageToDOB(12) });
       const found = await userService.findOne({}, { compute: ['age'] });
-      expect(found.age).to.equal(12);
+      expect(found).to.have.property('age', 12);
+    });
+    it('should return null if no object is found', async () => {
+      const found = await userService.findOne({});
+      expect(found).to.equal(null);
     });
   });
 
@@ -366,7 +370,11 @@ describe('SequelizeService', function () {
     it('should computeProperties object', async () => {
       const user = await userService.create({ email: 'foo', password: 'bar', date_of_birth: ageToDOB(12) });
       const found = await userService.findByPrimaryKey(user.id, { compute: ['age'] });
-      expect(found.age).to.equal(12);
+      expect(found).to.have.property('age', 12);
+    });
+    it('should return null if no object is found', async () => {
+      const found = await userService.findByPrimaryKey(1);
+      expect(found).to.equal(null);
     });
   });
 
@@ -550,7 +558,7 @@ describe('SequelizeService', function () {
       expect(await userService.count({})).to.equal(1);
       await userService.replaceOne({ email: 'foo' }, { email: 'foo', password: 'baz' });
       expect(await userService.count({})).to.equal(1);
-      expect((await userService.findOne({})).password).to.equal('baz');
+      expect((await userService.findOne({}))).to.have.property('password', 'baz');
     });
     it('should call create hooks', async () => {
       let calledBefore = false;


### PR DESCRIPTION
The compiler now knows null might be returned from the changed methods, which is what the actual code already did.