### PR TITLE
🐛 Fixed computed properties being calculated multiple times

### DIFF
--- a/src/classes/computed-properties-manager.ts
+++ b/src/classes/computed-properties-manager.ts
@@ -35,9 +35,6 @@ export abstract class ComputedPropertiesManager<W extends {}, R extends W, C ext
       } else {
         sequence[index].push(definition.property);
       }
-
-      sequence[index] = sequence[index] || [];
-      sequence[index].push(definition.property);
     });
 
     for (const group of sequence) {


### PR DESCRIPTION
I noticed computed properties being calculated twice, due to which appears to be some duplicated code (probably from a refactor).

Observe the new test case:
![Screen Shot 2019-04-26 at 5 47 25 PM](https://user-images.githubusercontent.com/287060/56842582-6f42de80-684b-11e9-80c0-00d6c727e17c.png)
